### PR TITLE
Update bookmark accessibility label after swiping pages

### DIFF
--- a/MinitexPDFProtocols/Book Reader/BookViewController.swift
+++ b/MinitexPDFProtocols/Book Reader/BookViewController.swift
@@ -219,15 +219,13 @@ class BookViewController: UIViewController, MinitexPDFViewController, UIPopoverP
             let pageIndex = pdfDocument?.index(for: currentPage) {
             let mark = MinitexPDFPage(pageNumber: UInt(pageIndex))
             if let index = bookmarks.index(of: pageIndex) {
-                bookmarkButton.image = (#imageLiteral(resourceName: "Bookmark-N") as WrappedBundleImage).image
-                bookmarkButton.accessibilityLabel = NSLocalizedString("Add Bookmark", comment: "")
                 self.bookmarks.remove(at: index)
                 self.delegate?.userDidDelete(bookmark: mark)
+                updateBookmarkButton(isBookmarked: false)
             } else {
-                bookmarkButton.image = (#imageLiteral(resourceName: "Bookmark-P") as WrappedBundleImage).image
-                bookmarkButton.accessibilityLabel = NSLocalizedString("Remove Bookmark", comment: "")
                 self.bookmarks = (bookmarks + [pageIndex]).sorted()
                 self.delegate?.userDidCreate(bookmark: mark)
+                updateBookmarkButton(isBookmarked: true)
             }
         }
     }
@@ -279,7 +277,7 @@ class BookViewController: UIViewController, MinitexPDFViewController, UIPopoverP
     private func updateBookmarkStatus() {
         if let currentPage = pdfView.currentPage,
             let index = pdfDocument?.index(for: currentPage) {
-            bookmarkButton.image = self.bookmarks.contains(index) ? (#imageLiteral(resourceName: "Bookmark-P") as WrappedBundleImage).image : (#imageLiteral(resourceName: "Bookmark-N") as WrappedBundleImage).image
+            updateBookmarkButton(isBookmarked: bookmarks.contains(index))
         }
     }
 
@@ -310,6 +308,16 @@ class BookViewController: UIViewController, MinitexPDFViewController, UIPopoverP
                 self.titleLabelContainer.alpha = 0
                 self.pageNumberLabelContainer.alpha = 0
             }
+        }
+    }
+    
+    private func updateBookmarkButton(isBookmarked: Bool) {
+        if isBookmarked {
+            bookmarkButton.image = (#imageLiteral(resourceName: "Bookmark-P") as WrappedBundleImage).image
+            bookmarkButton.accessibilityLabel = NSLocalizedString("Remove Bookmark", comment: "")
+        } else {
+            bookmarkButton.image = (#imageLiteral(resourceName: "Bookmark-N") as WrappedBundleImage).image
+            bookmarkButton.accessibilityLabel = NSLocalizedString("Add Bookmark", comment: "")
         }
     }
 }


### PR DESCRIPTION
This PR fixes accessibility label text on the bookmark button - it was keeping "Remove bookmark" text after bookmarking a page and then swiping to another one (related to this [notion ticket](https://www.notion.so/lyrasis/Add-a-name-attribute-for-pdf-bookmarks-ios-ee95093c67d54350a3e068533c5db10b)).