### PR TITLE
Fix application crash when PDFKit cannot generate page thumbnail

### DIFF
--- a/MinitexPDFProtocols/Book Reader/ThumbnailGridViewController.swift
+++ b/MinitexPDFProtocols/Book Reader/ThumbnailGridViewController.swift
@@ -62,8 +62,12 @@ class ThumbnailGridViewController: UICollectionViewController, UICollectionViewD
             } else {
                 let size = cellSize
                 downloadQueue.async {
-                    let thumbnail = page.thumbnail(of: size, for: .cropBox)
-                    self.thumbnailCache.setObject(thumbnail, forKey: key)
+                    // page.thumbnail(of:for:) can return uninitialized UIImage pointer,
+                    // we should use optional type to avoid crashes in this case
+                    let thumbnail: UIImage? = page.thumbnail(of: size, for: .cropBox)
+                    if let thumbnail = thumbnail {
+                        self.thumbnailCache.setObject(thumbnail, forKey: key)
+                    }
                     if cell.pageNumber == pageNumber {
                         DispatchQueue.main.async {
                             cell.image = thumbnail


### PR DESCRIPTION
This fixes a crash when PDFKit cannot generate page thumbnail in PDF files. ([Ticket](https://www.notion.so/lyrasis/App-crashes-when-you-try-to-read-Slavery-in-America-book-IOS-15-d21f0cd61f864559be81f4614f4c44a9)).

`page.thumbnail(of:for:)` signature returns non-optional `UIImage`, but in reality it can return uninitialized UIImage, and it crashes the app.