### PR TITLE
Fix PDF hide/show navigation logics

### DIFF
--- a/PDFRendererProvider.xcodeproj/project.pbxproj
+++ b/PDFRendererProvider.xcodeproj/project.pbxproj
@@ -93,7 +93,9 @@
 				52EB73702092676E003E8D00 /* MinitexPDFProtocolsTests */,
 				52EB73642092676D003E8D00 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		52EB73642092676D003E8D00 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This makes navigation bars hide/show behaviour similar between iOS 15 and earlier versions.

iOS 15 recognizes taps on PDFView itself, while iOS versions before 15 don't register these taps. This change also removes the additional tap gesture recognizer added to the PDFView parent view to hide/show navigation bars ([Ticket](https://www.notion.so/lyrasis/Can-t-activate-navigation-bar-for-PDFs-on-iOS-13-and-14-3cb5c44bca3a4d24b7c351fe34037275)).